### PR TITLE
Fix topic content routes to use unified service

### DIFF
--- a/src/content/services.py
+++ b/src/content/services.py
@@ -233,6 +233,36 @@ class ContentService(VerificationBaseService):
             logging.error(f"Error eliminando contenido: {str(e)}")
             return False, f"Error interno: {str(e)}"
 
+    def get_content(self, content_id: str) -> Optional[Dict]:
+        """Obtiene un contenido específico por su ID."""
+        try:
+            content = self.collection.find_one({"_id": ObjectId(content_id)})
+            if not content:
+                return None
+
+            content["_id"] = str(content["_id"])
+            content["topic_id"] = str(content["topic_id"])
+            if content.get("template_id"):
+                content["template_id"] = str(content["template_id"])
+            if content.get("creator_id"):
+                content["creator_id"] = str(content["creator_id"])
+
+            return content
+        except Exception as e:
+            logging.error(f"Error obteniendo contenido: {str(e)}")
+            return None
+
+    def adapt_content_to_methodology(self, content_id: str, methodology_code: str) -> Tuple[bool, Dict]:
+        """Adapta un contenido según una metodología de aprendizaje."""
+        try:
+            from src.study_plans.services import TopicContentService
+
+            topic_content_service = TopicContentService()
+            return topic_content_service.adapt_content_to_methodology(content_id, methodology_code)
+        except Exception as e:
+            logging.error(f"Error adaptando contenido: {str(e)}")
+            return False, {"error": str(e)}
+
 class VirtualContentService(VerificationBaseService):
     """
     Servicio para contenido personalizado por estudiante.

--- a/src/study_plans/routes.py
+++ b/src/study_plans/routes.py
@@ -1205,7 +1205,7 @@ def get_methodology_compatibility():
 def get_topic_contents(topic_id):
     """Obtiene todos los contenidos asociados a un tema"""
     try:
-        contents = topic_content_service.get_topic_contents(topic_id)
+        contents = topic_content_service.get_topic_content(topic_id)
         return APIRoute.success(data=contents)
     except Exception as e:
         logging.error(f"Error al obtener contenidos del tema: {str(e)}")
@@ -1220,7 +1220,7 @@ def get_topic_contents(topic_id):
 def get_topic_content_by_type(topic_id, content_type):
     """Obtiene todos los contenidos de un tema según su tipo"""
     try:
-        contents = topic_content_service.get_topic_content_by_type(topic_id, content_type)
+        contents = topic_content_service.get_topic_content(topic_id, content_type)
         if contents is None:
             return APIRoute.error(
                 ErrorCodes.SERVER_ERROR,


### PR DESCRIPTION
## Summary
- use `get_topic_content` instead of obsolete methods in topic routes
- provide `get_content` and `adapt_content_to_methodology` in unified ContentService

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6868d36a319c8327b4b5e0ab30abdcc3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved content retrieval with enhanced error handling and adaptability to different methodologies.

* **Refactor**
  * Updated topic content fetching logic to streamline internal processes without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->