### PR TITLE
Add evaluation submission and grading endpoints

### DIFF
--- a/src/study_plans/models.py
+++ b/src/study_plans/models.py
@@ -136,7 +136,8 @@ class Evaluation:
                  due_date: datetime,
                  use_quiz_score: bool = False,
                  requires_submission: bool = False,
-                 linked_quiz_id: Optional[str] = None):
+                 linked_quiz_id: Optional[str] = None,
+                 auto_grading: bool = False):
         self.module_id = ObjectId(module_id)
         self.title = title
         self.description = description
@@ -146,6 +147,7 @@ class Evaluation:
         self.use_quiz_score = use_quiz_score
         self.requires_submission = requires_submission
         self.linked_quiz_id = ObjectId(linked_quiz_id) if linked_quiz_id else None
+        self.auto_grading = auto_grading
         self.created_at = datetime.now()
         self.status = "pending"
 
@@ -161,7 +163,8 @@ class Evaluation:
             "status": self.status,
             "use_quiz_score": self.use_quiz_score,
             "requires_submission": self.requires_submission,
-            "linked_quiz_id": self.linked_quiz_id
+            "linked_quiz_id": self.linked_quiz_id,
+            "auto_grading": self.auto_grading
         }
 
 # DEPRECATED: Usar ContentResult en su lugar.


### PR DESCRIPTION
## Summary
- implement listing evaluations by module with student status
- add auto-grading service and integrate with submission upload
- support auto_grading flag in Evaluation model and service
- add endpoint to manually grade evaluations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests and bson)*

------
https://chatgpt.com/codex/tasks/task_e_68895dd01fec8327aa61d3f2ebf769d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatic grading of evaluation submissions.
  * Introduced new API endpoints to list evaluations for a module, upload and manage evaluation submissions, and manually or automatically grade submissions.
  * Users can now view evaluation statuses, submission details, and feedback.

* **Bug Fixes**
  * Improved error handling for file uploads and grading processes.

* **Chores**
  * Enhanced role-based access control for grading and submission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->