### PR TITLE
Fix topic query filter

### DIFF
--- a/src/virtual/services.py
+++ b/src/virtual/services.py
@@ -175,17 +175,18 @@ class VirtualTopicService(VerificationBaseService):
 
     def get_module_topics(self, module_id: str) -> List[Dict]:
         try:
-            topics = list(self.collection.find(
-                {
-                    "virtual_module_id": ObjectId(module_id),
-                    "status": {"$ne": "locked"}
-                }
-            ).sort("order", 1))
+            topics = list(
+                self.collection
+                .find({"virtual_module_id": ObjectId(module_id)})
+                .sort("order", 1)
+            )
             
             # Convertir ObjectIds a strings
             for topic in topics:
                 topic["_id"] = str(topic["_id"])
                 topic["virtual_module_id"] = str(topic["virtual_module_id"])
+                topic["locked"] = topic.get("locked", False)
+                topic["status"] = topic.get("status", "")
                 
             return topics
         except Exception as e:


### PR DESCRIPTION
## Summary
- keep locked and status fields when listing module topics
- simplify get_module_topics filter to not exclude locked topics

## Testing
- `python -m unittest discover -s src/tests` *(fails: ModuleNotFoundError: No module named 'bson')*

------
https://chatgpt.com/codex/tasks/task_e_688a8016093c8327b6fdd5eb04040adc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All topics for a given module are now displayed, regardless of their status.
  * Each topic now clearly shows whether it is locked and its status, even if this information was previously missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->