### PR TITLE
Normalize role casing in backend responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Se han realizado las siguientes mejoras para optimizar el funcionamiento y mante
    - Nuevos campos para marcadores de personalización en `TopicContent`
    - Extracción automática de marcadores al crear o actualizar contenido
 
+8. **Normalización de Roles**:
+   - Los roles de usuario se devuelven ahora en mayúsculas en tokens y respuestas
+   - Evita inconsistencias entre frontend y backend
+
 ## Variables de Entorno Requeridas
 
 El proyecto usa las siguientes variables de entorno que deben configurarse en un archivo `.env`:

--- a/src/members/services.py
+++ b/src/members/services.py
@@ -3,7 +3,7 @@ from bson import ObjectId
 from datetime import datetime
 
 from src.shared.database import get_db
-from src.shared.constants import ROLES
+from src.shared.constants import ROLES, normalize_role
 from src.shared.exceptions import AppException
 from src.shared.validators import is_valid_object_id, validate_object_id
 from src.shared.standardization import VerificationBaseService, ErrorCodes
@@ -391,7 +391,7 @@ class MembershipService(VerificationBaseService):
                 membership_info = membership_map.get(institute_id_str)
                 
                 if membership_info:
-                    institute["user_role"] = membership_info.get("role")
+                    institute["user_role"] = normalize_role(membership_info.get("role"))
                     institute["user_permissions"] = membership_info.get("permissions", {})
                     institute["joined_at"] = membership_info.get("joined_at")
                 
@@ -423,7 +423,7 @@ class MembershipService(VerificationBaseService):
                     "institute_id": str(m["institute_id"]),
                     "workspace_type": m.get("workspace_type", "INSTITUTE"),
                     "workspace_name": m.get("workspace_name") or (inst.get("name") if inst else None),
-                    "role": m.get("role"),
+                    "role": normalize_role(m.get("role")),
                 }
                 if inst:
                     workspace["institute"] = {

--- a/src/shared/constants.py
+++ b/src/shared/constants.py
@@ -20,6 +20,11 @@ ROLES = {
     "ADMIN": "admin"
 }
 
+
+def normalize_role(role: str) -> str:
+    """Devuelve el rol en mayúsculas para las respuestas JSON."""
+    return role.upper() if isinstance(role, str) else role
+
 # Types of workspaces
 WORKSPACE_TYPES = {
     "INSTITUTE": "INSTITUTE",

--- a/src/workspaces/routes.py
+++ b/src/workspaces/routes.py
@@ -8,6 +8,7 @@ from src.shared.decorators import workspace_access_required, workspace_owner_req
 from src.members.services import MembershipService
 from src.workspaces.services import WorkspaceService
 from src.shared.database import get_db
+from src.shared.constants import normalize_role
 
 workspaces_bp = APIBlueprint('workspaces', __name__)
 membership_service = MembershipService()
@@ -28,7 +29,7 @@ def list_workspaces():
                 "institute_id": str(workspace["institute_id"]),
                 "workspace_type": workspace.get("workspace_type"),
                 "workspace_name": workspace.get("workspace_name"),
-                "role_in_workspace": workspace.get("role"),
+                "role_in_workspace": normalize_role(workspace.get("role")),
                 "status": workspace.get("status", "active"),
                 "joined_at": workspace.get("joined_at"),
                 "class_id": str(workspace["class_id"]) if workspace.get("class_id") else None,
@@ -77,7 +78,7 @@ def switch_workspace(workspace_id):
         claims = {
             "workspace_id": workspace_id,
             "institute_id": str(membership["institute_id"]),
-            "role": membership.get("role"),
+            "role": normalize_role(membership.get("role")),
             "workspace_type": membership.get("workspace_type"),
             "workspace_name": membership.get("workspace_name")
         }
@@ -94,7 +95,7 @@ def switch_workspace(workspace_id):
             "workspace_id": workspace_id,
             "workspace_type": membership.get("workspace_type"),
             "workspace_name": membership.get("workspace_name"),
-            "role_in_workspace": membership.get("role"),
+            "role_in_workspace": normalize_role(membership.get("role")),
             "institute_id": str(membership["institute_id"]),
             "class_id": str(membership["class_id"]) if membership.get("class_id") else None
         }

--- a/src/workspaces/services.py
+++ b/src/workspaces/services.py
@@ -3,6 +3,7 @@ from bson import ObjectId
 from datetime import datetime
 from src.shared.database import get_db
 from src.shared.exceptions import AppException
+from src.shared.constants import normalize_role
 from src.classes.services import ClassService
 from src.study_plans.services import StudyPlanService
 from src.members.services import MembershipService
@@ -99,7 +100,7 @@ class WorkspaceService:
                 "workspace_id": str(membership["_id"]),
                 "workspace_type": membership.get("workspace_type", "INSTITUTE"),
                 "workspace_name": membership.get("workspace_name", institute["name"]),
-                "role_in_workspace": membership["role"],
+                "role_in_workspace": normalize_role(membership["role"]),
                 "institute_id": str(membership["institute_id"]),
                 "class_id": str(membership["class_id"]) if membership.get("class_id") else None,
                 "status": membership.get("status", "active"),
@@ -190,7 +191,7 @@ class WorkspaceService:
                 "workspace_id": workspace_id,
                 "workspace_type": workspace_type,
                 "workspace_name": workspace_name.strip(),
-                "role_in_workspace": role,
+                "role_in_workspace": normalize_role(role),
                 "institute_id": str(generic_institute["_id"]),
                 "class_id": str(membership_data.get("class_id")) if membership_data.get("class_id") else None,
                 "message": "Workspace personal creado exitosamente"


### PR DESCRIPTION
## Summary
- add helper to normalize roles to uppercase
- return roles in uppercase across auth, membership, and workspace endpoints
- document role casing expectations

## Testing
- `pytest src/tests/test_workspaces_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_689133b4b3148327a5d7598ec8744b12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User roles are now consistently returned in uppercase in tokens and API responses, improving consistency across the platform.

* **Documentation**
  * Updated the README to reflect the normalization of user roles in backend responses.

* **Tests**
  * Added a test to verify that user workspace roles are normalized to uppercase in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->