### PR TITLE
feat: expose topic theory and readiness endpoints

### DIFF
--- a/src/content/routes.py
+++ b/src/content/routes.py
@@ -150,6 +150,22 @@ def get_topic_content(topic_id):
             status_code=500,
         )
 
+
+@content_bp.route('/topic/<topic_id>/type/<content_type>', methods=['GET'])
+@jwt_required()
+def get_topic_content_by_type(topic_id, content_type):
+    """Obtiene el contenido de un tema filtrado por tipo"""
+    try:
+        contents = content_service.get_topic_content(topic_id, content_type)
+        return APIRoute.success(data={"contents": contents})
+    except Exception as e:
+        logging.error(f"Error obteniendo contenido por tipo: {str(e)}")
+        return APIRoute.error(
+            ErrorCodes.SERVER_ERROR,
+            "Error interno del servidor",
+            status_code=500,
+        )
+
 @content_bp.route('/topic/<topic_id>/interactive', methods=['GET'])
 @jwt_required()
 def get_interactive_content(topic_id):

--- a/src/study_plans/routes.py
+++ b/src/study_plans/routes.py
@@ -295,6 +295,53 @@ def toggle_topic_publication(topic_id):
         )
     return APIRoute.error(ErrorCodes.UPDATE_ERROR, message)
 
+
+@study_plan_bp.route('/topic/theory', methods=['GET'])
+@APIRoute.standard(auth_required_flag=True)
+def get_topic_theory():
+    """Obtiene el contenido teórico de un tema"""
+    topic_id = request.args.get('topic_id')
+    if not topic_id:
+        return APIRoute.error(ErrorCodes.MISSING_FIELD, "ID del topic es requerido")
+    result = topic_service.get_theory_content(topic_id)
+    if not result:
+        return APIRoute.error(ErrorCodes.NOT_FOUND, "Topic no encontrado")
+    return APIRoute.success(data=result)
+
+
+@study_plan_bp.route('/topic/theory', methods=['PUT'])
+@APIRoute.standard(auth_required_flag=True, roles=[ROLES["TEACHER"]], required_fields=['topic_id', 'theory_content'])
+def update_topic_theory():
+    """Actualiza el contenido teórico de un tema"""
+    data = request.get_json()
+    topic_id = data.get('topic_id')
+    theory_content = data.get('theory_content', '')
+    success, message = topic_service.update_theory_content(topic_id, theory_content)
+    if success:
+        return APIRoute.success(message=message)
+    return APIRoute.error(ErrorCodes.UPDATE_ERROR, message)
+
+
+@study_plan_bp.route('/topic/theory', methods=['DELETE'])
+@APIRoute.standard(auth_required_flag=True, roles=[ROLES["TEACHER"]])
+def delete_topic_theory():
+    """Elimina el contenido teórico de un tema"""
+    topic_id = request.args.get('topic_id')
+    if not topic_id:
+        return APIRoute.error(ErrorCodes.MISSING_FIELD, "ID del topic es requerido")
+    success, message = topic_service.delete_theory_content(topic_id)
+    if success:
+        return APIRoute.success(message=message)
+    return APIRoute.error(ErrorCodes.DELETE_ERROR, message)
+
+
+@study_plan_bp.route('/topic/<topic_id>/readiness-status', methods=['GET'])
+@APIRoute.standard(auth_required_flag=True)
+def get_topic_readiness_status(topic_id):
+    """Verifica si un tema está listo para ser publicado"""
+    result = topic_readiness_service.check_readiness(topic_id)
+    return APIRoute.success(data=result)
+
 @study_plan_bp.route('/module/<module_id>/topics', methods=['GET'])
 @APIRoute.standard(auth_required_flag=True)
 def get_module_topics(module_id):


### PR DESCRIPTION
## Summary
- expose CRUD endpoints for topic theory content
- add readiness status endpoint for topics
- support content retrieval by topic and type

## Testing
- `pytest` *(fails: DB_NAME not configured)*

------
https://chatgpt.com/codex/tasks/task_e_689420f803a4832789c0b20dc25cd010