### PR TITLE
Align ContentResult with virtual content and add user endpoints

### DIFF
--- a/src/content/models.py
+++ b/src/content/models.py
@@ -186,34 +186,36 @@ class VirtualTopicContent:
         }
 
 class ContentResult:
-    """
-    Almacena el resultado de la interacción de un estudiante con una pieza de contenido.
-    Unifica los resultados de quizzes, juegos, simulaciones, etc.
-    """
-    def __init__(self,
-                 content_id: str,
-                 student_id: str,
-                 score: float,
-                 virtual_content_id: Optional[str] = None,
-                 feedback: Optional[str] = None,
-                 metrics: Optional[Dict] = None,
-                 session_type: str = "content_interaction",
-                 _id: Optional[ObjectId] = None,
-                 recorded_at: Optional[datetime] = None):
+    """Stores the outcome of a student's interaction with content."""
+
+    def __init__(
+        self,
+        student_id: str,
+        score: float,
+        content_id: Optional[str] = None,
+        virtual_content_id: Optional[str] = None,
+        feedback: Optional[str] = None,
+        metrics: Optional[Dict] = None,
+        session_type: str = "content_interaction",
+        _id: Optional[ObjectId] = None,
+        recorded_at: Optional[datetime] = None,
+    ):
+        if not content_id and not virtual_content_id:
+            raise ValueError("content_id or virtual_content_id is required")
+
         self._id = _id or ObjectId()
-        self.content_id = ObjectId(content_id)
-        self.student_id = ObjectId(student_id)
+        self.content_id = ObjectId(content_id) if content_id else None
         self.virtual_content_id = ObjectId(virtual_content_id) if virtual_content_id else None
+        self.student_id = ObjectId(student_id)
         self.score = score
         self.feedback = feedback
-        self.metrics = metrics or {} # e.g., time_spent, attempts, etc.
+        self.metrics = metrics or {}
         self.session_type = session_type
         self.recorded_at = recorded_at or datetime.now()
 
     def to_dict(self) -> dict:
         data = {
             "_id": self._id,
-            "content_id": self.content_id,
             "student_id": self.student_id,
             "score": self.score,
             "feedback": self.feedback,
@@ -221,6 +223,8 @@ class ContentResult:
             "session_type": self.session_type,
             "recorded_at": self.recorded_at,
         }
+        if self.content_id:
+            data["content_id"] = self.content_id
         if self.virtual_content_id:
             data["virtual_content_id"] = self.virtual_content_id
         return data

--- a/src/virtual/services.py
+++ b/src/virtual/services.py
@@ -2311,19 +2311,19 @@ class VirtualContentProgressService(VerificationBaseService):
             
             # Preparar datos para ContentResult
             content_result_data = {
-                "content_id": str(virtual_content.get("content_id", virtual_content["_id"])),
+                "virtual_content_id": str(virtual_content["_id"]),
+                "content_id": str(virtual_content.get("original_content_id")) if virtual_content.get("original_content_id") else None,
                 "student_id": student_id,
                 "score": score,
                 "feedback": "Contenido completado automáticamente",
                 "metrics": {
                     "content_type": virtual_content.get("content_type", "unknown"),
-                    "virtual_content_id": str(virtual_content["_id"]),
                     "auto_completed": True,
                     "completion_time": session_data.get("time_spent", 0),
                     "interaction_count": session_data.get("interactions", 1),
                     "personalization_applied": bool(virtual_content.get("personalization_data"))
                 },
-                "session_type": "auto_completion"
+                "session_type": "auto_completion",
             }
             
             # Crear ContentResult


### PR DESCRIPTION
## Summary
- enforce `ContentResult` to reference virtual content and derive score/metrics from session data
- expose `/api/users/check` and `/api/users/profile/cognitive` endpoints
- adjust automatic result creation for virtual contents

## Testing
- `pytest` *(fails: ImportError: cannot import name 'TopicResource' from 'src.study_plans.models')*


------
https://chatgpt.com/codex/tasks/task_e_68abd147d59c832789698bf91c6fe6de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added endpoints to verify a user by email (POST /users/check).
  * Added endpoints to view and update your cognitive profile (GET/PUT /users/profile/cognitive).

* Bug Fixes
  * More reliable recording of content results when only virtual content is present; correctly assigns identifiers.
  * Improved score calculation from session data when missing and consolidated metrics.
  * Safer serialization of optional fields to prevent missing/invalid IDs in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->