### PR TITLE
Return explicit error for invalid JWT tokens

### DIFF
--- a/src/shared/decorators.py
+++ b/src/shared/decorators.py
@@ -89,8 +89,8 @@ def auth_required(f):
             logger.error(f"Auth_required: Error de autenticación: {str(e)}")
             return jsonify({
                 "success": False,
-                "error": "ERROR_AUTENTICACION",
-                "message": "Error de autenticación"
+                "error": "TOKEN_INVALIDO",
+                "message": "Token inválido o expirado"
             }), 401
     return decorated_function
 


### PR DESCRIPTION
## Summary
- return an explicit JSON payload with `TOKEN_INVALIDO` when JWT authentication fails

## Testing
- `pytest` *(fails: DB_NAME no está configurado)*

------
https://chatgpt.com/codex/tasks/task_e_68ba723dafec8327ae6965ff934c5c1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication error response for invalid or expired tokens, returning a clearer Spanish message and a consistent error code. The HTTP status remains 401.
  * Improves clarity and consistency for client applications handling authentication failures; no changes to endpoints or status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->